### PR TITLE
Enable get week of current month

### DIFF
--- a/Sources/CalendarView/CalendarViewModel.swift
+++ b/Sources/CalendarView/CalendarViewModel.swift
@@ -146,3 +146,17 @@ final public class CalendarViewModel: ObservableObject {
         )
     }
 }
+
+// MARK: - Calendar public API
+public extension CalendarViewModel {
+
+    /// Return `Week` from current selected month
+    /// - Parameter index: Index of week in current monht
+    /// - Returns: Week in current month if exist
+    func week(of index: Int) -> Week? {
+        let weeks = current.weeks
+
+        guard weeks.count > index else { return nil }
+        return weeks[index]
+    }
+}

--- a/Sources/CalendarView/DayView.swift
+++ b/Sources/CalendarView/DayView.swift
@@ -1,20 +1,20 @@
 import SwiftUI
 
-struct Day {
-    let number: Int
-    var isHeighlighted = false
-    var isSelected = false
-    var isEnabled = true
-    var isCurrent = false
-    var onSelect: (() -> Void) = {}
+public struct Day {
+    public let number: Int
+    public var isHeighlighted = false
+    public var isSelected = false
+    public var isEnabled = true
+    public var isCurrent = false
+    public var onSelect: (() -> Void) = {}
 }
 
-struct DayView: View {
-    let day: Day
+public struct DayView: View {
+    public let day: Day
 
     @Environment(\.calendarStyle) private var style: CalendarStyleProtocol
 
-    var body: some View {
+    public var body: some View {
         ZStack {
             Text("\(day.number)")
                 .font(.system(size: 14))

--- a/Sources/CalendarView/MonthView.swift
+++ b/Sources/CalendarView/MonthView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
-struct MonthView: View {
-    let weeks: [Week]
+public struct MonthView: View {
+    public let weeks: [Week]
 
-    var body: some View {
+    public var body: some View {
         VStack {
             ForEach(weeks, content: WeekView.init(week:))
         }

--- a/Sources/CalendarView/WeekView.swift
+++ b/Sources/CalendarView/WeekView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-struct Week: Identifiable {
-    let id = UUID()
-    let days: [Day]
+public struct Week: Identifiable {
+    public let id = UUID()
+    public let days: [Day]
 }
 
-struct WeekView: View {
+public struct WeekView: View {
     let week: Week
 
-    var body: some View {
+    public var body: some View {
         HStack {
             ForEach(week.days, id: \.number) {
                 DayView(day: $0)

--- a/Tests/CalendarViewTests/CalendarViewTests.swift
+++ b/Tests/CalendarViewTests/CalendarViewTests.swift
@@ -2,14 +2,24 @@ import XCTest
 @testable import CalendarView
 
 final class CalendarViewTests: XCTestCase {
-//    func testExample() {
-//        // This is an example of a functional test case.
-//        // Use XCTAssert and related functions to verify your tests produce the correct
-//        // results.
-////        XCTAssertEqual(CalendarView().text, "Hello, World!")
-//    }
-//
-//    static var allTests = [
-////        ("testExample", testExample),
-//    ]
+
+    static var allTests = [
+        ("testGetWeek", testGetWeek),
+    ]
+
+
+    func testGetWeek() {
+        let calendarViewModel = CalendarViewModel(
+            today: Date(timeIntervalSince1970: 0),
+            heighlighted: [],
+            selectedDate: nil
+        )
+
+        // Get second week of week ( first is 0 )
+        let week = calendarViewModel.week(of: 1)
+
+        XCTAssertNotNil(week)
+        XCTAssertEqual(week?.days.count, 7)
+        XCTAssertEqual(week?.days.first?.number, 4)
+    }
 }


### PR DESCRIPTION
 Add an extension to return `Week` from the current selected month

```
let viewModel: CalendarViewModel
....
let week = viewModel.week(of: 1)
```